### PR TITLE
Fixed bug in variable

### DIFF
--- a/idle.py
+++ b/idle.py
@@ -9,7 +9,9 @@ import os
 import subprocess as sp
 import sys
 import time, datetime
-now = datetime.datetime.now
+
+
+now = datetime.datetime.now()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The variable now stores the memory location of the method datetime.datetime.now() instead of executing the method.